### PR TITLE
Adjusting DCMOF library for querying worklists by calling AE title

### DIFF
--- a/dcm4che-tool/dcm4che-tool-dcmof/src/main/java/org/dcm4che2/tool/dcmof/MWLSCP.java
+++ b/dcm4che-tool/dcm4che-tool-dcmof/src/main/java/org/dcm4che2/tool/dcmof/MWLSCP.java
@@ -75,8 +75,8 @@ class MWLSCP extends CFindService {
     @Override
     protected DimseRSP doCFind(Association as, int pcid, DicomObject cmd,
             DicomObject keys, DicomObject rsp) throws DicomServiceException {
-        String calledAET = as.getCalledAET();
-        if (calledAET != null && !calledAET.equals("ANY-SCP")) {
+        String callingAET = as.getCallingAET();
+        if (callingAET != null && !callingAET.equals("FINDSCU")) {
             DicomElement dicomElement = keys.get(Tag.ScheduledProcedureStepSequence);
             DicomObject dicomObject = dicomElement.getDicomObject(0);
             dicomObject.remove(Tag.ScheduledStationAETitle);


### PR DESCRIPTION
Changes allow filtering of requested worklists by AE title of requestor (calling AE title) - by default this filtering is not executed by DcmOF service.